### PR TITLE
Fixed input bug

### DIFF
--- a/src/angular2-app/coe/coe-simulation.component.html
+++ b/src/angular2-app/coe/coe-simulation.component.html
@@ -11,7 +11,7 @@
 <div *ngIf="online" class="alert alert-success">
   {{coeVersions[coeSimulation.getMaestroVersion()]}}, version {{ coeSimulation.getCoeVersion() }}, online at {{ coeSimulation.coeUrl }}.
 </div>
-<h5 *ngIf="!correctCoeVersion || !online" class="text-warning">Simulation requires that {{coeVersions[required_coe_version]}} is running</h5>
+<h5 *ngIf="required_coe_version && (!correctCoeVersion || !online)" class="text-warning">Simulation requires that {{coeVersions[required_coe_version]}} is running</h5>
 
 <div *ngIf="mmWarnings.length > 0">
   <strong>The multi model configuration is not valid.</strong>

--- a/src/angular2-app/coe/coe-simulation.component.ts
+++ b/src/angular2-app/coe/coe-simulation.component.ts
@@ -46,8 +46,8 @@ import { maestroVersions } from "../shared/maestro-api.service";
 
 @Component({
   selector: "coe-simulation",
-/*   providers: [CoeSimulationService],
-  directives: [LineChartComponent], */
+  providers: [CoeSimulationService],
+/* directives: [LineChartComponent], */
   templateUrl: "./angular2-app/coe/coe-simulation.component.html"
 })
 export class CoeSimulationComponent implements OnDestroy {

--- a/src/angular2-app/coe/coe.module.ts
+++ b/src/angular2-app/coe/coe.module.ts
@@ -32,7 +32,6 @@ import { NgModule } from "@angular/core";
 import { BrowserModule } from '@angular/platform-browser'
 import { FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { CoePageComponent } from "./coe-page.component";
-import { CoeSimulationService } from "./coe-simulation.service";
 import { SharedModule } from "../shared/shared.module";
 import { CoeConfigurationComponent } from "./coe-configuration.component";
 import { ZeroCrossingComponent } from "./inputs/zero-crossing.component";
@@ -56,8 +55,7 @@ import { LineChartComponent } from "../shared/line-chart.component";
         LiveGraphComponent,
         CoeSimulationComponent,
         LineChartComponent],
-    exports: [CoePageComponent, CoeSimulationComponent],
-    providers: [CoeSimulationService]
+    exports: [CoePageComponent, CoeSimulationComponent]
 })
 export class COEModule {
 


### PR DESCRIPTION
The input boxes in the "Initial values of parameters" section in the mm-configuration view loses focus if a timer is running.
To fix this I have ensured that the timer that checks if the coe is online only is running when the coe-simulation service is in use, e.g. in the simulation view.
Closes #173 